### PR TITLE
Bump grain to 0.0.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
     install_requires=[
         'absl-py',
         'clu @ git+https://github.com/google/CommonLoopUtils#egg=clu',
-        'grain-nightly==0.0.6',
+        'grain-nightly==0.0.7',
         f'jax >= {_jax_version}',
         f'jaxlib >= {_jaxlib_version}',
         (


### PR DESCRIPTION
Starting from version 0.0.7 grain provides aarch64 wheels ([pypi](https://pypi.org/project/grain-nightly/0.0.7/#files)). Bumping the version dependency here will allow downstream users [such as the T5X build in JAX-Toolbox](https://github.com/NVIDIA/JAX-Toolbox/blob/7758db183ebf971c19daf4834dd6ad407b6533a9/.github/container/Dockerfile.t5x.arm64#L80-L149) to avoid workarounds for aarch64.